### PR TITLE
allow use of svgStyles for backwards compatability

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,12 @@ const defaults = {
 function D3Node (opts) {
   const options = Object.assign({}, defaults, opts)
 
+  // deprecates props
+  if (opts && opts.svgStyles) { // deprecated svgStyles option
+    console.warn('WARNING: svgStyles is deprecated, please use styles instead !!')
+    options.styles = opts.svgStyles
+  }
+
   // auto-new instance, so we always have 'this'
   if (!(this instanceof D3Node)) {
     return new D3Node(options)

--- a/test/index.js
+++ b/test/index.js
@@ -63,7 +63,7 @@ describe('createSVG (w/ svgStyles) 1', function () {
     var options = {
       selector: '#chart',
       container: '<div id="container"><div id="chart"></div></div>',
-      styles: '.test1{}'
+      svgStyles: '.test1{}'
     }
 
     var d3n = new D3Node(options)
@@ -76,7 +76,7 @@ describe('createSVG (w/ svgStyles) 1', function () {
   })
 })
 
-describe('createSVG (w/ svgStyles) 2', function () {
+describe('createSVG (w/ styles)', function () {
   it('should return svg', function () {
     var options = {
       selector: '#chart',


### PR DESCRIPTION
Need to deprecate external props instead of removing.
