### PR TITLE
Allow passing attributes to SVG element

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -52,13 +52,19 @@ function D3Node ({ d3Module = d3, selector = '', container = '', styles = '', sv
   this.d3 = d3Module
 }
 
-D3Node.prototype.createSVG = function (width, height) {
+D3Node.prototype.createSVG = function (width, height, attrs) {
   const svg = this.d3Element.append('svg')
     .attr('xmlns', 'http://www.w3.org/2000/svg')
 
   if (width && height) {
     svg.attr('width', width)
       .attr('height', height)
+  }
+
+  if (attrs) {
+    Object.keys(attrs).forEach(function (key) {
+      svg.attr(key, attrs[key])
+    })
   }
 
   if (this.options.styles) {

--- a/test/index.js
+++ b/test/index.js
@@ -115,6 +115,18 @@ describe('createSVG (w/ width & height)', function () {
   })
 })
 
+describe('createSVG (w/ width & viewBox)', function () {
+  it('should return svg', function () {
+    var d3n = new D3Node()
+
+    d3n.createSVG(null, null, {width: '100%', viewBox: '0 0 574 308'}).append('g')
+
+    var expected = '<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 574 308"><g></g></svg>'
+    var actual = d3n.svgString()
+    assert.equal(actual, expected)
+  })
+})
+
 describe('svgString() should retain camel-casing', function () {
   var d3n = new D3Node()
   d3n.createSVG()


### PR DESCRIPTION
It is  common to want the svg to have more than just the `width` and `height` attributes on the root element. For instance, `viewBox` is key for creating responsive svgs.

This pull request adds the ability to pass miscellaneous attributes via an optional `attrs` parameter, which takes an object with keys for attribute names.

closes #40