### PR TITLE
Fix broken canvas initialization.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-(Fork with fixed canvas!)
 # D3-Node  
 [![Build Status](https://travis-ci.org/d3-node/d3-node.svg?branch=master)](https://travis-ci.org/d3-node/d3-node)
 [![Codecov](https://img.shields.io/codecov/c/github/d3-node/d3-node.svg)](https://travis-ci.org/d3-node/d3-node)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+(Fork with fixed canvas!)
 # D3-Node  
 [![Build Status](https://travis-ci.org/d3-node/d3-node.svg?branch=master)](https://travis-ci.org/d3-node/d3-node)
 [![Codecov](https://img.shields.io/codecov/c/github/d3-node/d3-node.svg)](https://travis-ci.org/d3-node/d3-node)

--- a/src/index.js
+++ b/src/index.js
@@ -83,7 +83,7 @@ D3Node.prototype.createCanvas = function (width, height) {
     throw new Error('Install node-canvas for HTMLCanvasElement support.')
   }
 
-  const canvas = new Canvas(width, height)
+  const canvas = new Canvas.Canvas(width, height)
   this.options.canvas = canvas
   return canvas
 }


### PR DESCRIPTION
Node-canvas and The Canvas constructor is no longer the default export from the module since ver. 2.0 so currently d3-node can't work with latest versions of node-canvas. 
In this pr i've fixed it.
