### PR TITLE
fix canvas inititalization (due to node-canvas update to ver.2)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -83,7 +83,11 @@ D3Node.prototype.createCanvas = function (width, height) {
     throw new Error('Install node-canvas for HTMLCanvasElement support.')
   }
 
-  const canvas = new Canvas(width, height)
+  if (parseInt(Canvas.version) >= 2)
+    const canvas = new Canvas.Canvas(width, height)
+  else
+    const canvas = new Canvas(width, height)
+    
   this.options.canvas = canvas
   return canvas
 }


### PR DESCRIPTION
Node-canvas and The Canvas constructor is no longer the default export from the module since ver. 2.0 so currently d3-node can't work with latest versions of node-canvas.
In this pr i've fixed it. Also supports canvas v.1 